### PR TITLE
fix VS2010 define to compile with gcc

### DIFF
--- a/triangle.c
+++ b/triangle.c
@@ -344,10 +344,12 @@
 // #define VS2010
 
 /* Added to remove deprecation warnings from strcpy and fopen */
+#ifdef _MSC_VER
 #ifdef VS2010
 	#define _CRT_SECURE_NO_WARNINGS
 #else
 	#error "Warning! Deprecation warning, this code uses strcpy and fopen!"
+#endif
 #endif
 
 #include <stdio.h>


### PR DESCRIPTION
Making triangle on Linux with gcc failed because of the VS2010 conditional directive in line 347. I suppose this is only relevant using visual studio c compiler, so I added one more #ifdef to avoid the strange error with gcc.